### PR TITLE
JSON Creation For Guides Documentation

### DIFF
--- a/src/content/docs/Products/SplashKit/Splashkit Website/Tutorials Documentation/07-Tutorial-JSON.mdx
+++ b/src/content/docs/Products/SplashKit/Splashkit Website/Tutorials Documentation/07-Tutorial-JSON.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tutorial JSON File
+title: Tutorial links in API Documentation pages using JSON Files
 description: Use this as a guide to create JSON files for your new tutorial.
 sidebar:
   label: Tutorial JSON File
@@ -8,13 +8,18 @@ sidebar:
 
 import { FileTree } from "@astrojs/starlight/components";
 
-JSON files are used to connect the guides page with the documentation site.
+For the [splashkit.io](https://splashkit.io/) website, JSON files are now used to list all the
+functions used in the guides pages, to link them in to the API documentation pages for SplashKit
+users to see if a function has been demonstrated in any of the guides.
 
-### Directory 
+Here is information about how this is set up:
+
+### Directory
 
 <FileTree>
 
 - scripts/
+  - json-files/
     - guides/
       - Animations/
         - animations.json
@@ -41,39 +46,41 @@ JSON files are used to connect the guides page with the documentation site.
 
 </FileTree>
 
-When creating a folder for a new category, it can be placed within the guides folder. The JSON file for a certain category should be the folder's name in lowercase.
+When creating a folder for a new category, it can be placed within the guides folder. The JSON file
+for a certain category should be the folder's name in lowercase.
 
-### Content 
+### Content
 
-Each guides' entry need to contain a name, an array of the functions used, and the url to the guide page.
-It is important to use the function's **unique_global_name** to ensure the correct function is linked on the documentation site. Each new addition can be added consecutively using the curly brackets.
+Each guides' entry need to contain a name, an array of the functions used, and the url to the guide
+page. It is important to use the function's **unique_global_name** to ensure the correct function is
+linked on the documentation site. Each new addition can be added consecutively using the curly
+brackets.
 
 ```json
 {
-    "guides": [
-        {
-            "name": "Introduction to JSON in SplashKit",
-            "functions": [
-                "json_from_file",
-                "json_read_string",
-                "write_line",
-                "free_json",
-                "json_has_key"
-            ],
-            "url": "/guides/json/0-json_intro/"
-        },
-        {
-            "name": "Reading JSON Data in SplashKit",
-            "functions": [
-                "json_read_array_of_string",
-                "write_line",
-                "write",
-                "json_read_object",
-                "json_read_number_as_int"
-            ],
-            "url": "/guides/json/1-json_reading/"
-        }
-    ]
+  "guides": [
+    {
+      "name": "Introduction to JSON in SplashKit",
+      "functions": [
+        "json_from_file",
+        "json_read_string",
+        "write_line",
+        "free_json",
+        "json_has_key"
+      ],
+      "url": "/guides/json/0-json_intro/"
+    },
+    {
+      "name": "Reading JSON Data in SplashKit",
+      "functions": [
+        "json_read_array_of_string",
+        "write_line",
+        "write",
+        "json_read_object",
+        "json_read_number_as_int"
+      ],
+      "url": "/guides/json/1-json_reading/"
+    }
+  ]
 }
 ```
-

--- a/src/content/docs/Products/SplashKit/Splashkit Website/Tutorials Documentation/07-Tutorial-JSON.mdx
+++ b/src/content/docs/Products/SplashKit/Splashkit Website/Tutorials Documentation/07-Tutorial-JSON.mdx
@@ -1,0 +1,79 @@
+---
+title: Tutorial JSON File
+description: Use this as a guide to create JSON files for your new tutorial.
+sidebar:
+  label: Tutorial JSON File
+  order: 7
+---
+
+import { FileTree } from "@astrojs/starlight/components";
+
+JSON files are used to connect the guides page with the documentation site.
+
+### Directory 
+
+<FileTree>
+
+- scripts/
+    - guides/
+      - Animations/
+        - animations.json
+      - Audio/
+        - audio.json
+      - Camera/
+        - camera.json
+      - Graphics/
+        - graphics.json
+      - Input/
+        - input.json
+      - Interface/
+        - interface.json
+      - JSON/
+        - json.json
+      - Networking/
+        - networking.json
+      - Raspberry-GPIO/
+        - raspberry-gpio.json
+      - Resource-Bundles/
+        - resource-bundles.json
+      - Utilities/
+        - ultilies.json
+
+</FileTree>
+
+When creating a folder for a new category, it can be placed within the guides folder. The JSON file for a certain category should be the folder's name in lowercase.
+
+### Content 
+
+Each guides' entry need to contain a name, an array of the functions used, and the url to the guide page.
+It is important to use the function's **unique_global_name** to ensure the correct function is linked on the documentation site. Each new addition can be added consecutively using the curly brackets.
+
+```json
+{
+    "guides": [
+        {
+            "name": "Introduction to JSON in SplashKit",
+            "functions": [
+                "json_from_file",
+                "json_read_string",
+                "write_line",
+                "free_json",
+                "json_has_key"
+            ],
+            "url": "/guides/json/0-json_intro/"
+        },
+        {
+            "name": "Reading JSON Data in SplashKit",
+            "functions": [
+                "json_read_array_of_string",
+                "write_line",
+                "write",
+                "json_read_object",
+                "json_read_number_as_int"
+            ],
+            "url": "/guides/json/1-json_reading/"
+        }
+    ]
+}
+```
+


### PR DESCRIPTION
# Description

Added a documentation on how to create JSON files or add on to one for the linking of the API documentation page and the guides page.

# CheckList 

- [x] npm run dev

# Files Added 

- [x] Tutorial Documentation/Tutorial JSON file.mdx