### PR TITLE
Fixed typo in SplashKit website create usage example guide ln 68

### DIFF
--- a/src/content/docs/Products/SplashKit/Splashkit Website/Usage Examples/02-creating-usage-examples.mdx
+++ b/src/content/docs/Products/SplashKit/Splashkit Website/Usage Examples/02-creating-usage-examples.mdx
@@ -65,7 +65,7 @@ A complete usage example includes:
    C++, C# (using top-level statements and OOP version), and Python, all using Splashkit. Start with
    the language you're most comfortable with, then convert it to the others.
 
-   Note for C# to-level: Use `using static SplashkitSDK.SplashKit;`. For the OOP version: use
+   Note for C# to-level: Use `using static SplashKitSDK.SplashKit;`. For the OOP version: use
    `using SplashKitSDK;`.
 
    #### Example


### PR DESCRIPTION
# Fixed typo in Create Usage Example guide for SplashKit Website

Current guide will cause an error for anyone that copy pastes the example namespace 

updated `using static SplashkitSDK.SplashKit;`  -> `using static SplashKitSDK.SplashKit;` 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Ran build and preview to confirm change reflects correctly

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
