### PR TITLE
fix: GitHub deprecated workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Linelint
         uses: fernandrone/linelint@master
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: 24.14.0
       - name: Install dependencies


### PR DESCRIPTION
# Description

Fixing the warning for deprecated CI actions:

<img width="833" height="309" alt="image" src="https://github.com/user-attachments/assets/874dfc30-785b-4d8d-b8e1-81d253c90116" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

See below CI checks...